### PR TITLE
Restore semicolon delimiters in .dbn files created from .sql files

### DIFF
--- a/src/helpers/SQLHelper.ts
+++ b/src/helpers/SQLHelper.ts
@@ -1611,7 +1611,7 @@ export const separateMultipleQueries = (text: string): string[] => {
   text.match(pattern)?.forEach((token) => {
     if (token === ';') {
       if (currentToken.length > 0) {
-        queries.push(currentToken.join('').trim());
+        queries.push(currentToken.join('').trim() + ';'); // Add the semicolon back
         currentToken = [];
       }
     } else {


### PR DESCRIPTION
Using [Database Notebook VSCode extension](https://github.com/l-v-yonsama/db-notebook) I noticed that when I created a `.dbn` file from a `.sql` file, all the semicolons (_statement terminators_) that were present in the original `.sql` file were not present in the `.dbn` file. All semicolons created directly in the `.dbn` file did remain there correctly as expected. In the `.dbn` file, queries seemed to work with or without those semicolons, but if I want to copy code from there, I had to manually add all the missing semicolons after pasting it. So I just added `+ ';'`  in **line 1614** in `/src/helpers/SQLHelper.ts` in the `separateMultipleQueries` definition part.

