### PR TITLE
Get column comments on the correct schema on postgres

### DIFF
--- a/src/drivers/PostgresDriver.ts
+++ b/src/drivers/PostgresDriver.ts
@@ -440,13 +440,16 @@ ORDER BY A.pid DESC
       COLUMN_DEFAULT as col_default,
       null as col_extra,
       (
-      select
-        pg_catalog.col_description(oid,
-        col.ordinal_position::int)
-      from
-        pg_catalog.pg_class c
-      where
-        c.relname = col.table_name) as comment
+	    select
+    		pg_catalog.col_description(c.oid,
+	    	col.ordinal_position::int)
+    	from
+    		pg_catalog.pg_class c
+	    inner join pg_catalog.pg_namespace n on
+	    	c.relnamespace = n.oid
+	    where
+	    	c.relname = col.table_name
+	    	and n.nspname = col.table_schema) as comment
     from
       INFORMATION_SCHEMA.columns col
     left join (


### PR DESCRIPTION
The column request fails with the following error when a column exists on different schemas with the same table name.

> SQL Error [21000]: ERROR: more than one row returned by a subquery used as an expression

Further investigations led to discover that the comment sub-query is missing a filter on the schema.

I got this error because the Database notebook extension failed to analyse my postgres database.